### PR TITLE
Added logic for Learning rate adjustment based on input step size.  This is disabled by default. 

### DIFF
--- a/classification/models/ResNet.py
+++ b/classification/models/ResNet.py
@@ -300,7 +300,7 @@ class Moco(nn.Module):
 
         self.FC = nn.Linear(2048, numCls)
 
-        self.apply(weights_init_kaiming)
+        self.conv1.apply(weights_init_kaiming)
         self.apply(fc_init_weights)
 
     def forward(self, x):


### PR DESCRIPTION
Added logic for Learning rate adjustment based on input step size. This is disabled by default. 
We can enable it by using --use_lr_step. Example: --lr 0.00001 **--use_lr_step** --lr_step_size 30
